### PR TITLE
Enable flake's nixConfig on GHA for garnix 

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,12 @@
+name: 'Setup Nix'
+description: 'Installs Nix and configures binary caches'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Nix
+      # "DeterminateSystems/nix-installer-action" does not run on x86_64-darwin: https://github.com/DeterminateSystems/nix-src/issues/224
+      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+      with:
+        extra_nix_config: |
+          sandbox = true
+          accept-flake-config = true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,18 @@ updates:
     ignore:
       - dependency-name: 'crate-ci/typos'
     cooldown:
-      default-days: 7
+      default-days: 3
+  - package-ecosystem: 'github-actions'
+    directory: '/.github/actions/setup-nix'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'crate-ci/typos'
+    cooldown:
+      default-days: 3
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
+      default-days: 3

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,8 +37,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      # "DeterminateSystems/nix-installer-action" does not run on x86_64-darwin: https://github.com/DeterminateSystems/nix-src/issues/224
-      - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+      - uses: ./.github/actions/setup-nix
       - run: nix build
 
   flake:
@@ -48,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+      - uses: ./.github/actions/setup-nix
       - run: nix flake check
       - run: nix flake show
 
@@ -69,7 +68,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+      - uses: ./.github/actions/setup-nix
       - run: echo 'This step should be done before any other "nix develop" steps to measure the setup time'
       - run: cargo fmt --check
       - run: cargo clippy -- --deny warnings


### PR DESCRIPTION
Follow-up: https://github.com/kachick/nixpkgs-update-log-checker/commit/b36644fed4744954cbd5ffc537277dfb4a8d87db