### PR TITLE
Integrate crane for incremental builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1772560058,
+        "narHash": "sha256-NuVKdMBJldwUXgghYpzIWJdfeB7ccsu1CC7B+NfSoZ8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "db590d9286ed5ce22017541e36132eab4e8b3045",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770141374,
@@ -15,6 +30,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -10,16 +10,57 @@
 
   inputs = {
     nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs =
     {
       nixpkgs,
+      crane,
       ...
     }:
     let
       lib = nixpkgs.lib;
       forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+
+      mkCraneLib = pkgs: crane.mkLib pkgs;
+
+      mkCommonArgs =
+        pkgs:
+        let
+          craneLib = mkCraneLib pkgs;
+        in
+        {
+          src = craneLib.cleanCargoSource ./.;
+          strictDeps = true;
+
+          buildInputs =
+            [
+              # Add any runtime dependencies here
+            ]
+            ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+              # Additional darwin specific inputs can be added here
+            ];
+        };
+
+      mkArtifacts =
+        pkgs:
+        let
+          craneLib = mkCraneLib pkgs;
+          commonArgs = mkCommonArgs pkgs;
+        in
+        craneLib.buildDepsOnly commonArgs;
+
+      mkPackage =
+        pkgs:
+        let
+          craneLib = mkCraneLib pkgs;
+          commonArgs = mkCommonArgs pkgs;
+          cargoArtifacts = mkArtifacts pkgs;
+        in
+        pkgs.callPackage ./package.nix {
+          inherit craneLib cargoArtifacts commonArgs;
+        };
     in
     {
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
@@ -30,8 +71,36 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         rec {
-          nixpkgs-update-log-checker = pkgs.callPackage ./package.nix { };
+          nixpkgs-update-log-checker = mkPackage pkgs;
           default = nixpkgs-update-log-checker;
+        }
+      );
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          craneLib = mkCraneLib pkgs;
+          commonArgs = mkCommonArgs pkgs;
+          cargoArtifacts = mkArtifacts pkgs;
+          nixpkgs-update-log-checker = mkPackage pkgs;
+        in
+        {
+          inherit nixpkgs-update-log-checker;
+          # Build the dependencies once and then reuse them for each check
+          nixpkgs-update-log-checker-clippy = craneLib.cargoClippy (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+            }
+          );
+
+          nixpkgs-update-log-checker-fmt = craneLib.cargoFmt (commonArgs // { inherit cargoArtifacts; });
+
+          nixpkgs-update-log-checker-nextest = craneLib.cargoNextest (
+            commonArgs // { inherit cargoArtifacts; }
+          );
         }
       );
 

--- a/package.nix
+++ b/package.nix
@@ -1,41 +1,36 @@
 {
   lib,
-  rustPlatform,
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
   versionCheckHook,
 }:
 
 let
   mainProgram = "nixpkgs-update-log-checker";
 in
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nixpkgs-update-log-checker";
-  version = with builtins; (fromTOML (readFile ./Cargo.toml)).package.version;
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    pname = "nixpkgs-update-log-checker";
+    version = with builtins; (fromTOML (readFile ./Cargo.toml)).package.version;
 
-  src = lib.fileset.toSource {
-    root = ./.;
-    fileset = lib.fileset.unions [
-      ./src
-      ./Cargo.toml
-      ./Cargo.lock
+    nativeInstallCheckInputs = [
+      versionCheckHook
     ];
-  };
+    doInstallCheck = true;
+    versionCheckProgram = "${placeholder "out"}/bin/${mainProgram}";
+    versionCheckProgramArg = "--version";
 
-  cargoLock.lockFile = ./Cargo.lock;
-
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
-  doInstallCheck = true;
-  versionCheckProgram = "${placeholder "out"}/bin/${mainProgram}";
-  versionCheckProgramArg = "--version";
-
-  meta = {
-    inherit mainProgram;
-    description = "CLI to check the update log of nixpkgs";
-    homepage = "https://github.com/kachick/nixpkgs-update-log-checker";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      kachick
-    ];
-  };
-})
+    meta = {
+      inherit mainProgram;
+      description = "CLI to check the update log of nixpkgs";
+      homepage = "https://github.com/kachick/nixpkgs-update-log-checker";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        kachick
+      ];
+    };
+  }
+)

--- a/src/log_analysis.rs
+++ b/src/log_analysis.rs
@@ -14,6 +14,7 @@ pub fn analyze_log(raw: &str) -> Result<LogAnalysisResult> {
         return Ok(LogAnalysisResult::Failure);
     }
 
+    // :)
     if let Some(last_line) = lines.last() {
         if last_line.starts_with("error") {
             return Ok(LogAnalysisResult::Failure);


### PR DESCRIPTION
- Add crane as a flake input
- Refactor package.nix to use craneLib
- Separate dependency build (cargoArtifacts) from package build
- Add clippy, fmt, and nextest checks to flake outputs
- Refactor flake.nix to use helper functions for crane integration
