### PR TITLE
Skip infinite recursion logs dated 2026-07-04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .direnv
 
 result
+
+!tests/fixtures/*.log

--- a/src/log_analysis.rs
+++ b/src/log_analysis.rs
@@ -6,8 +6,8 @@ pub enum LogAnalysisResult {
     Skip,
 }
 
-pub fn analyze_log(raw: &str) -> Result<LogAnalysisResult> {
-    if raw.contains("infinite recursion encountered") {
+pub fn analyze_log(raw: &str, log_url: &str) -> Result<LogAnalysisResult> {
+    if log_url.contains("/2026-07-04.log") && raw.contains("infinite recursion encountered") {
         return Ok(LogAnalysisResult::Skip);
     }
 
@@ -78,7 +78,11 @@ Diff after rewrites:
 
 [pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
 https://api.github.com/repos/NixOS/nixpkgs/pulls/392589"#;
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/dprint/2025-03-24.log",
+        )
+        .unwrap();
         match result {
             LogAnalysisResult::Success { pr_url } => {
                 assert_eq!(
@@ -98,7 +102,11 @@ https://api.github.com/repos/NixOS/nixpkgs/pulls/392589"#;
 
 [pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
 https://api.github.com/repos/NixOS/nixpkgs/pulls/395562"#;
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/plemoljp/2025-04-02.log",
+        )
+        .unwrap();
         match result {
             LogAnalysisResult::Success { pr_url } => {
                 assert_eq!(
@@ -126,7 +134,11 @@ Enqueuing group of 1 packages
 Packages updated!
 
 The diff was empty after rewrites.";
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/dprint/2025-04-13.log",
+        )
+        .unwrap();
         match result {
             LogAnalysisResult::Success { pr_url } => {
                 assert_eq!(pr_url, None);
@@ -139,7 +151,11 @@ The diff was empty after rewrites.";
     fn test_analyze_log_failure_with_no_success() {
         // Extracted from https://nixpkgs-update-logs.nix-community.org/fishnet/2025-04-10.log
         let log = "fishnet 2.9.4 -> 2.9.5 https://github.com/lichess-org/fishnet/releases";
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/fishnet/2025-04-10.log",
+        )
+        .unwrap();
         assert!(matches!(result, LogAnalysisResult::Failure));
     }
 
@@ -158,7 +174,11 @@ Received ExitFailure 1 when running
 Raw command: nix-build --option sandbox true --arg config "{ allowBroken = true; allowUnfree = true; allowAliases = false; }" --arg overlays "[ ]" -A chawan
 nix build failed.
 [01m[Kgcc:[m[K [01;31m[Kerror: [m[Kthe: linker input file not found: No such file or directory"#;
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/chawan/2025-05-04.log",
+        )
+        .unwrap();
         assert!(matches!(result, LogAnalysisResult::Failure));
     }
 
@@ -175,7 +195,11 @@ Diff after rewrites:
 
 error: build log of 'dbeaver' is not available
 "#;
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/dbeaver/2024-05-16.log",
+        )
+        .unwrap();
         assert!(matches!(result, LogAnalysisResult::Failure));
     }
 
@@ -198,28 +222,55 @@ No auto update branch exists
 [updateScript] skipping because derivation has no updateScript
 The diff was empty after rewrites.
 "#;
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/stockfish/2025-05-13.log",
+        )
+        .unwrap();
         assert!(matches!(result, LogAnalysisResult::Skip));
     }
 
     #[test]
     fn test_analyze_log_infinite_recursion_betterleaks() {
         let log = include_str!("../tests/fixtures/betterleaks-2026-07-04.log");
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/betterleaks/2026-07-04.log",
+        )
+        .unwrap();
         assert!(matches!(result, LogAnalysisResult::Skip));
     }
 
     #[test]
     fn test_analyze_log_infinite_recursion_brush() {
         let log = include_str!("../tests/fixtures/brush-2026-07-04.log");
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/brush/2026-07-04.log",
+        )
+        .unwrap();
         assert!(matches!(result, LogAnalysisResult::Skip));
     }
 
     #[test]
     fn test_analyze_log_infinite_recursion_typescript_go() {
         let log = include_str!("../tests/fixtures/typescript-go-2026-07-04.log");
-        let result = analyze_log(log).unwrap();
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/typescript-go/2026-07-04.log",
+        )
+        .unwrap();
         assert!(matches!(result, LogAnalysisResult::Skip));
+    }
+
+    #[test]
+    fn test_analyze_log_infinite_recursion_other_date_fails() {
+        let log = include_str!("../tests/fixtures/betterleaks-2026-07-04.log");
+        let result = analyze_log(
+            log,
+            "https://nixpkgs-update-logs.nix-community.org/betterleaks/2026-07-05.log",
+        )
+        .unwrap();
+        assert!(matches!(result, LogAnalysisResult::Failure));
     }
 }

--- a/src/log_analysis.rs
+++ b/src/log_analysis.rs
@@ -3,10 +3,14 @@ use anyhow::Result;
 pub enum LogAnalysisResult {
     Success { pr_url: Option<String> },
     Failure,
-    NoUpdater,
+    Skip,
 }
 
 pub fn analyze_log(raw: &str) -> Result<LogAnalysisResult> {
+    if raw.contains("infinite recursion encountered") {
+        return Ok(LogAnalysisResult::Skip);
+    }
+
     let lines: Vec<&str> = raw.trim_end().lines().collect();
 
     // Should return early. See GH-6
@@ -31,7 +35,7 @@ pub fn analyze_log(raw: &str) -> Result<LogAnalysisResult> {
     }
 
     if lines.contains(&"[updateScript] skipping because derivation has no updateScript") {
-        return Ok(LogAnalysisResult::NoUpdater);
+        return Ok(LogAnalysisResult::Skip);
     }
 
     let keywords = [
@@ -159,7 +163,7 @@ nix build failed.
     }
 
     #[test]
-    fn test_analyze_log_ending_failed_prefers_no_updater() {
+    fn test_analyze_log_ending_failed_prefers_skip() {
         // Extracted from https://nixpkgs-update-logs.nix-community.org/dbeaver/2024-05-16.log
         let log = r#"dbeaver 22.2.2 -> 24.0.4 https://github.com/dbeaver/dbeaver/releases
 attrpath: dbeaver
@@ -195,6 +199,27 @@ No auto update branch exists
 The diff was empty after rewrites.
 "#;
         let result = analyze_log(log).unwrap();
-        assert!(matches!(result, LogAnalysisResult::NoUpdater));
+        assert!(matches!(result, LogAnalysisResult::Skip));
+    }
+
+    #[test]
+    fn test_analyze_log_infinite_recursion_betterleaks() {
+        let log = include_str!("../tests/fixtures/betterleaks-2026-07-04.log");
+        let result = analyze_log(log).unwrap();
+        assert!(matches!(result, LogAnalysisResult::Skip));
+    }
+
+    #[test]
+    fn test_analyze_log_infinite_recursion_brush() {
+        let log = include_str!("../tests/fixtures/brush-2026-07-04.log");
+        let result = analyze_log(log).unwrap();
+        assert!(matches!(result, LogAnalysisResult::Skip));
+    }
+
+    #[test]
+    fn test_analyze_log_infinite_recursion_typescript_go() {
+        let log = include_str!("../tests/fixtures/typescript-go-2026-07-04.log");
+        let result = analyze_log(log).unwrap();
+        assert!(matches!(result, LogAnalysisResult::Skip));
     }
 }

--- a/src/package_checker.rs
+++ b/src/package_checker.rs
@@ -89,7 +89,7 @@ pub async fn check_package(client: &Client, pname: &str) -> Result<PackageCheckR
 
     let latest_log_url = log_urls[0].clone();
     let latest_log = client.get(&latest_log_url).send().await?.text().await?;
-    match log_analysis::analyze_log(&latest_log)? {
+    match log_analysis::analyze_log(&latest_log, &latest_log_url)? {
         log_analysis::LogAnalysisResult::Success { pr_url } => Ok(PackageCheckResult::Success {
             log_url: latest_log_url,
             pr_url,

--- a/src/package_checker.rs
+++ b/src/package_checker.rs
@@ -97,7 +97,7 @@ pub async fn check_package(client: &Client, pname: &str) -> Result<PackageCheckR
         log_analysis::LogAnalysisResult::Failure => Ok(PackageCheckResult::Failure {
             log_url: latest_log_url,
         }),
-        log_analysis::LogAnalysisResult::NoUpdater => Ok(PackageCheckResult::Skip {
+        log_analysis::LogAnalysisResult::Skip => Ok(PackageCheckResult::Skip {
             log_url: latest_log_url,
         }),
     }

--- a/tests/fixtures/betterleaks-2026-07-04.log
+++ b/tests/fixtures/betterleaks-2026-07-04.log
@@ -1,0 +1,281 @@
+Running nixpkgs-update (https://nix-community.org/update-bot/) with UPDATE_INFO: betterleaks 0 -> 1
+attrpath: betterleaks
+Checking auto update branch...
+Received ExitFailure 1 when running
+Raw command: nix-env -f /var/cache/nixpkgs-update/worker/outpath/outpaths.nix -qaP --no-name --out-path --arg path /var/cache/nixpkgs-update/worker/worktree/betterleaks --arg checkMeta true --show-trace
+Standard output:
+
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+error:
+       â¦ while evaluating the attribute 'aider-chat-full'
+
+       â¦ while evaluating the attribute 'x86_64-linux'
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:42:6:
+           41|   tweak = lib.mapAttrs
+           42|     (name: val:
+             |      ^
+           43|       if name == "recurseForDerivations" then true
+
+       â¦ while calling anonymous lambda
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:42:12:
+           41|   tweak = lib.mapAttrs
+           42|     (name: val:
+             |            ^
+           43|       if name == "recurseForDerivations" then true
+
+       â¦ while evaluating a branch condition
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:12:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |            ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ in the left operand of the AND (&&) operator
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:31:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |                               ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ while calling the 'isAttrs' builtin
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:15:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |               ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/attrsets.nix:1348:61:
+         1347|   */
+         1348|   genAttrs = names: f: genAttrs' names (n: nameValuePair n (f n));
+             |                                                             ^
+         1349|
+
+       â¦ while calling anonymous lambda
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/top-level/release-lib.nix:181:38:
+          180|     crossSystem: metaPatterns: f:
+          181|     forMatchingSystems metaPatterns (system: hydraJob' (f (pkgsForCross crossSystem system)));
+             |                                      ^
+          182|
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/top-level/release-lib.nix:181:46:
+          180|     crossSystem: metaPatterns: f:
+          181|     forMatchingSystems metaPatterns (system: hydraJob' (f (pkgsForCross crossSystem system)));
+             |                                              ^
+          182|
+
+       â¦ while calling 'hydraJob'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:464:5:
+          463|   hydraJob =
+          464|     drv:
+             |     ^
+          465|     let
+
+       â¦ while calling the 'deepSeq' builtin
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:497:35:
+          496|     in
+          497|     if drv == null then null else deepSeq drv' drv';
+             |                                   ^
+          498|
+
+       â¦ while evaluating the attribute 'outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:486:13:
+          485|           value = commonAttrs // {
+          486|             outPath = output.outPath;
+             |             ^
+          487|             drvPath = output.drvPath;
+
+       â¦ while evaluating the attribute 'outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'aider-chat-playwright-browser-help-bedrock-0.86.1'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'aider-chat-playwright-browser-help-bedrock-0.86.1'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-llama-index-embeddings-huggingface-0.7.0'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.13-llama-index-embeddings-huggingface-0.7.0'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-sentence-transformers-5.4.1'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'nativeBuildInputs' of derivation 'python3.13-sentence-transformers-5.4.1'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:719:11:
+          718|           depsBuildBuild = buildBuildOutputs;
+          719|           nativeBuildInputs = buildHostOutputs;
+             |           ^
+          720|           depsBuildTarget = buildTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-torchaudio-2.11.0'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'nativeBuildInputs' of derivation 'python3.13-torchaudio-2.11.0'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:719:11:
+          718|           depsBuildBuild = buildBuildOutputs;
+          719|           nativeBuildInputs = buildHostOutputs;
+             |           ^
+          720|           depsBuildTarget = buildTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-fairseq-0.12.3'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.13-fairseq-0.12.3'
+         at /var/cache/nixpkgs-update/worker/worktree/betterleaks/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       error: infinite recursion encountered
+

--- a/tests/fixtures/brush-2026-07-04.log
+++ b/tests/fixtures/brush-2026-07-04.log
@@ -1,0 +1,281 @@
+Running nixpkgs-update (https://nix-community.org/update-bot/) with UPDATE_INFO: brush 0 -> 1
+attrpath: brush
+Checking auto update branch...
+Received ExitFailure 1 when running
+Raw command: nix-env -f /var/cache/nixpkgs-update/worker/outpath/outpaths.nix -qaP --no-name --out-path --arg path /var/cache/nixpkgs-update/worker/worktree/brush --arg checkMeta true --show-trace
+Standard output:
+
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+error:
+       â¦ while evaluating the attribute 'aider-chat-full'
+
+       â¦ while evaluating the attribute 'x86_64-linux'
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:42:6:
+           41|   tweak = lib.mapAttrs
+           42|     (name: val:
+             |      ^
+           43|       if name == "recurseForDerivations" then true
+
+       â¦ while calling anonymous lambda
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:42:12:
+           41|   tweak = lib.mapAttrs
+           42|     (name: val:
+             |            ^
+           43|       if name == "recurseForDerivations" then true
+
+       â¦ while evaluating a branch condition
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:12:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |            ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ in the left operand of the AND (&&) operator
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:31:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |                               ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ while calling the 'isAttrs' builtin
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:15:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |               ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/attrsets.nix:1348:61:
+         1347|   */
+         1348|   genAttrs = names: f: genAttrs' names (n: nameValuePair n (f n));
+             |                                                             ^
+         1349|
+
+       â¦ while calling anonymous lambda
+         at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/top-level/release-lib.nix:181:38:
+          180|     crossSystem: metaPatterns: f:
+          181|     forMatchingSystems metaPatterns (system: hydraJob' (f (pkgsForCross crossSystem system)));
+             |                                      ^
+          182|
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/top-level/release-lib.nix:181:46:
+          180|     crossSystem: metaPatterns: f:
+          181|     forMatchingSystems metaPatterns (system: hydraJob' (f (pkgsForCross crossSystem system)));
+             |                                              ^
+          182|
+
+       â¦ while calling 'hydraJob'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:464:5:
+          463|   hydraJob =
+          464|     drv:
+             |     ^
+          465|     let
+
+       â¦ while calling the 'deepSeq' builtin
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:497:35:
+          496|     in
+          497|     if drv == null then null else deepSeq drv' drv';
+             |                                   ^
+          498|
+
+       â¦ while evaluating the attribute 'outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:486:13:
+          485|           value = commonAttrs // {
+          486|             outPath = output.outPath;
+             |             ^
+          487|             drvPath = output.drvPath;
+
+       â¦ while evaluating the attribute 'outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'aider-chat-playwright-browser-help-bedrock-0.86.1'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'aider-chat-playwright-browser-help-bedrock-0.86.1'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-llama-index-embeddings-huggingface-0.7.0'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.13-llama-index-embeddings-huggingface-0.7.0'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-sentence-transformers-5.4.1'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'nativeBuildInputs' of derivation 'python3.13-sentence-transformers-5.4.1'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:719:11:
+          718|           depsBuildBuild = buildBuildOutputs;
+          719|           nativeBuildInputs = buildHostOutputs;
+             |           ^
+          720|           depsBuildTarget = buildTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-torchaudio-2.11.0'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'nativeBuildInputs' of derivation 'python3.13-torchaudio-2.11.0'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:719:11:
+          718|           depsBuildBuild = buildBuildOutputs;
+          719|           nativeBuildInputs = buildHostOutputs;
+             |           ^
+          720|           depsBuildTarget = buildTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-fairseq-0.12.3'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.13-fairseq-0.12.3'
+         at /var/cache/nixpkgs-update/worker/worktree/brush/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       error: infinite recursion encountered
+

--- a/tests/fixtures/typescript-go-2026-07-04.log
+++ b/tests/fixtures/typescript-go-2026-07-04.log
@@ -1,0 +1,281 @@
+Running nixpkgs-update (https://nix-community.org/update-bot/) with UPDATE_INFO: typescript-go 0 -> 1
+attrpath: typescript-go
+Checking auto update branch...
+Received ExitFailure 1 when running
+Raw command: nix-env -f /var/cache/nixpkgs-update/worker/outpath/outpaths.nix -qaP --no-name --out-path --arg path /var/cache/nixpkgs-update/worker/worktree/typescript-go --arg checkMeta true --show-trace
+Standard output:
+
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'DisnixWebService' has been renamed to 'disnix-web-service'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'LycheeSlicer' has been renamed to 'lycheeslicer'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'QuadProgpp' has been renamed to 'quadprogpp'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: 'Xaw3d' has been renamed to 'libxaw3d'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box' has been renamed to '_86box'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+evaluation warning: '_86Box-with-roms' has been renamed to '_86box-with-roms'
+error:
+       â¦ while evaluating the attribute 'aider-chat-full'
+
+       â¦ while evaluating the attribute 'x86_64-linux'
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:42:6:
+           41|   tweak = lib.mapAttrs
+           42|     (name: val:
+             |      ^
+           43|       if name == "recurseForDerivations" then true
+
+       â¦ while calling anonymous lambda
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:42:12:
+           41|   tweak = lib.mapAttrs
+           42|     (name: val:
+             |            ^
+           43|       if name == "recurseForDerivations" then true
+
+       â¦ while evaluating a branch condition
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:12:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |            ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ in the left operand of the AND (&&) operator
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:31:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |                               ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ while calling the 'isAttrs' builtin
+         at /var/cache/nixpkgs-update/worker/outpath/outpaths.nix:44:15:
+           43|       if name == "recurseForDerivations" then true
+           44|       else if lib.isAttrs val && val.type or null != "derivation"
+             |               ^
+           45|               then recurseIntoAttrs (tweak val)
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/attrsets.nix:1348:61:
+         1347|   */
+         1348|   genAttrs = names: f: genAttrs' names (n: nameValuePair n (f n));
+             |                                                             ^
+         1349|
+
+       â¦ while calling anonymous lambda
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/top-level/release-lib.nix:181:38:
+          180|     crossSystem: metaPatterns: f:
+          181|     forMatchingSystems metaPatterns (system: hydraJob' (f (pkgsForCross crossSystem system)));
+             |                                      ^
+          182|
+
+       â¦ from call site
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/top-level/release-lib.nix:181:46:
+          180|     crossSystem: metaPatterns: f:
+          181|     forMatchingSystems metaPatterns (system: hydraJob' (f (pkgsForCross crossSystem system)));
+             |                                              ^
+          182|
+
+       â¦ while calling 'hydraJob'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:464:5:
+          463|   hydraJob =
+          464|     drv:
+             |     ^
+          465|     let
+
+       â¦ while calling the 'deepSeq' builtin
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:497:35:
+          496|     in
+          497|     if drv == null then null else deepSeq drv' drv';
+             |                                   ^
+          498|
+
+       â¦ while evaluating the attribute 'outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:486:13:
+          485|           value = commonAttrs // {
+          486|             outPath = output.outPath;
+             |             ^
+          487|             drvPath = output.drvPath;
+
+       â¦ while evaluating the attribute 'outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'aider-chat-playwright-browser-help-bedrock-0.86.1'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'aider-chat-playwright-browser-help-bedrock-0.86.1'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-llama-index-embeddings-huggingface-0.7.0'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.13-llama-index-embeddings-huggingface-0.7.0'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-sentence-transformers-5.4.1'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'nativeBuildInputs' of derivation 'python3.13-sentence-transformers-5.4.1'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:719:11:
+          718|           depsBuildBuild = buildBuildOutputs;
+          719|           nativeBuildInputs = buildHostOutputs;
+             |           ^
+          720|           depsBuildTarget = buildTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-torchaudio-2.11.0'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'nativeBuildInputs' of derivation 'python3.13-torchaudio-2.11.0'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:719:11:
+          718|           depsBuildBuild = buildBuildOutputs;
+          719|           nativeBuildInputs = buildHostOutputs;
+             |           ^
+          720|           depsBuildTarget = buildTargetOutputs;
+
+       â¦ while evaluating the attribute 'out.outPath'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/lib/customisation.nix:431:11:
+          430|             drv.${outputName}.drvPath;
+          431|           outPath =
+             |           ^
+          432|             assert condition;
+
+       â¦ while calling the 'getAttr' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:50:17:
+           49|     value = commonAttrs // {
+           50|       outPath = builtins.getAttr outputName strict;
+             |                 ^
+           51|       drvPath = strict.drvPath;
+
+       â¦ while calling the 'derivationStrict' builtin
+         at Â«nix-internalÂ»/derivation-internal.nix:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       â¦ while evaluating derivation 'python3.13-fairseq-0.12.3'
+         whose name attribute is located at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:651:11
+
+       â¦ while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.13-fairseq-0.12.3'
+         at /var/cache/nixpkgs-update/worker/worktree/typescript-go/pkgs/stdenv/generic/make-derivation.nix:729:11:
+          728|           depsHostHostPropagated = propagatedHostHostOutputs;
+          729|           propagatedBuildInputs = propagatedHostTargetOutputs;
+             |           ^
+          730|           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
+
+       error: infinite recursion encountered
+


### PR DESCRIPTION
We recently encountered temporary infinite recursion errors during
nixpkgs-update on 2026-07-04 due to dependencies like aider-chat-playwright-browser-help-bedrock-0.86.1.
To prevent these false positives, we skip infinite recursion errors if
the log date is exactly "2026-07-04".

Other infinite recursion errors from different dates will still be
using real logs from the incident.